### PR TITLE
[*] MO : Fix Blocklinks to avoid 'undefined index' notice when editing existing link

### DIFF
--- a/blocklink.php
+++ b/blocklink.php
@@ -156,9 +156,13 @@ class BlockLink extends Module
 				$link['url'] = $results['url'];
 				$link['newWindow'] = $results['new_window'];
 
-			$results_lang = Db::getInstance()->executeS('SELECT `id_lang`, `text` FROM '._DB_PREFIX_.'blocklink_lang WHERE `id_blocklink`='.(int)$link['id_blocklink']);
-			foreach ($results_lang as $result_lang)
+			$results_lang = Db::getInstance()->executeS('SELECT l.`id_lang`, bl.`text` FROM `'._DB_PREFIX_.'lang` l LEFT JOIN `'._DB_PREFIX_.'blocklink_lang` bl ON l.`id_lang`=bl.`id_lang` WHERE bl.`id_blocklink`='.(int)$link['id_blocklink'].' OR bl.`id_blocklink` IS NULL');
+			foreach ($results_lang as $result_lang){
+				if ($result_lang['text'] == NULL)
+					$result_lang['text'] = false;
+
 				$link['text'][$result_lang['id_lang']] = $result_lang['text'];
+			}
 			return $link;
 		}
 


### PR DESCRIPTION
# Introduction

I use the 'Improvement' notation in the commit text because the module seems to work ok without any modification, but a notice is displayed when trying to edit existing links, saying that some undefined offset exist.
# Reproducing the Notice

To reproduce the 'Notice' I'm fixing with this request, follow the next steps:
1. Enable debug mode with error reporting level that enables notices
2. Make sure that you have installed more than one language but leave some of them not active
3. Go to Blocklinks module configuration screen
4. Add some links (one is enough) with text in only one language
5. On the "Link List" at the bottom, click on a link to edit, and when the page loads the notice is displayed.
# Cause and solution
## Cause

At the **getConfigFieldsValues()** method, the **array_merge()** php method used to merge **$fields_values** with the link values returned by **getLinkById()**, does not merge the ['text'] array that both include but replaces the ['text'] array from **$fields_values** with the one returned by **getLinkById()**.

When more than one language it enabled (let's say 3 languages), the **getConfigFieldsValues()** method initializes the **$fields_values['text']** using every available language, so the initialization of the array **$fields_values['text']** is something like:

``` php
["text"]=> array(3) { [1]=> bool(false) [2]=> bool(false) [3]=> bool(false) }
```

In the same scenario, the **getLinkById()** method fills the **$link['text']** array with only the items that exist in some language, so if a link only has text in Spanish, but English and French are enabled, the **$link['text]** will be something like:

``` php
["text"]=> array(3) { [3]=> string(16) "Recambios Lavabo" }
```

The expected result of the array_merge would be:

``` php
["text"]=> array(3) { [1]=> bool(false) [2]=> bool(false) [3]=> string(16) "Recambios Lavabo" }
```

But the actual merge returns:

``` php
["text"]=> array(3) { [3]=> string(16) "Recambios Lavabo" }
```

If two or more array elements have the same key, the last one overrides the others when using **array_merge()**, and that's the cause of the notice.
## Solution

The approach I followed to fix this, is to make **getLinkById()** always return the array values for every language, so I changed the SQL query to return:

| id_lang | text | id_blocklink |
| --- | --- | --- |
| 1 | NULL | NULL |
| 2 | NULL | NULL |
| 3 | Recambios Lavabo | 1 |

Instead of:

| id_lang | text | id_blocklink |
| --- | --- | --- |
| 3 | Recambios Lavabo | 1 |

And then, inside the foreach loop, the NULLs are included as boolean false to comply with the "expected result" of a real "merge".
