### PR TITLE
[*] MO : add support to extra hooks

### DIFF
--- a/blocklink.php
+++ b/blocklink.php
@@ -133,6 +133,26 @@ class BlockLink extends Module
 		return $this->hookLeftColumn($params);
 	}
 
+	public function hookDisplayTop($params)
+	{
+		return $this->hookLeftColumn($params);
+	}
+	
+	public function hookDisplayTopColumn($params)
+	{
+		return $this->hookLeftColumn($params);
+	}	
+	
+	public function hookDisplayNav($params)
+    {
+        return $this->hookLeftColumn($params);
+    }
+	
+	public function hookDisplayFooter($params)
+	{
+		return $this->hookLeftColumn($params);
+	}	
+
 	public function hookHeader($params)
 	{
 		$this->context->controller->addCSS($this->_path.'blocklink.css', 'all');


### PR DESCRIPTION
Add extra hooks support : DisplayTop, DisplayTopColumn, DisplayNav, DisplayFooter.

With this improvement, you can choose to display this module where you want.
This new hooks are not installed by default : you have to attach the blocklink module to the hook in prestashop backoffice